### PR TITLE
feat(validation): Implement dynamic validation registry integration  

### DIFF
--- a/lib/composables/useFormik.ts
+++ b/lib/composables/useFormik.ts
@@ -1,11 +1,13 @@
 import { computed, reactive, toRaw, watch, ref, type UnwrapRef } from "vue";
 import { clearObject, getNestedValue, setNestedValue, deepClone } from "@/helpers";
-import type { FormikHelpers } from "@/types";
+import type { AllowedAny, FormikHelpers } from "@/types";
 import { ObjectSchema as YupSchema } from "yup";
 import { ObjectSchema as JoiSchema } from "joi";
 import { ZodType } from "zod";
 import { CustomValidationSchema, FormikOnSubmit, IResetOptions } from "@/types";
 import validation from "@/composables/validation";
+import ValidationRegistry from "validation/registry";
+import { getValidationRegistryWithDefaults } from "@/composables/validation/registry/util";
 
 type FieldElement = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
 
@@ -18,6 +20,7 @@ const useFormik = <T extends object>({
   onSubmit,
   validateOnMount = true,
   preventDefault = true,
+  customValidators,
 }: {
   initialValues: T;
   validateOnMount?: boolean;
@@ -27,6 +30,7 @@ const useFormik = <T extends object>({
   joiSchema?: JoiSchema<T>;
   zodSchema?: ZodType<T>;
   validationSchema?: CustomValidationSchema<T>;
+  customValidators?: AllowedAny;
 }) => {
   // Refs for tracking form state
   const isSubmitting = ref(false);
@@ -34,13 +38,21 @@ const useFormik = <T extends object>({
   const submitCount = ref(0);
   const initialValuesRef = reactive<T>(deepClone(initialValues));
 
+  // validation registry init
+  const vRegistry = getValidationRegistryWithDefaults();
+
   const validate = () => {
-    return validation(toRaw(values) as T, {
-      yupSchema,
-      joiSchema,
-      zodSchema,
-      validationSchema,
-    });
+    return validation(
+      toRaw(values) as T,
+      vRegistry,
+      {
+        yupSchema,
+        joiSchema,
+        zodSchema,
+        validationSchema,
+        customValidators,
+      },
+    );
   };
 
   // Reactive form state

--- a/lib/composables/useFormik.ts
+++ b/lib/composables/useFormik.ts
@@ -6,7 +6,6 @@ import { ObjectSchema as JoiSchema } from "joi";
 import { ZodType } from "zod";
 import { CustomValidationSchema, FormikOnSubmit, IResetOptions } from "@/types";
 import validation from "@/composables/validation";
-import ValidationRegistry from "validation/registry";
 import { getValidationRegistryWithDefaults } from "@/composables/validation/registry/util";
 
 type FieldElement = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
@@ -42,17 +41,13 @@ const useFormik = <T extends object>({
   const vRegistry = getValidationRegistryWithDefaults();
 
   const validate = () => {
-    return validation(
-      toRaw(values) as T,
-      vRegistry,
-      {
-        yupSchema,
-        joiSchema,
-        zodSchema,
-        validationSchema,
-        customValidators,
-      },
-    );
+    return validation(toRaw(values) as T, vRegistry, {
+      yupSchema,
+      joiSchema,
+      zodSchema,
+      validationSchema,
+      customValidators,
+    });
   };
 
   // Reactive form state

--- a/lib/composables/validation/custom.ts
+++ b/lib/composables/validation/custom.ts
@@ -1,6 +1,5 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { getNestedValue, setNestedValue } from "@/helpers";
-import { CustomValidationSchema, ValidationRule } from "@/types";
+import { CustomValidationSchema, ValidationRule, AllowedAny } from "@/types";
 
 const isValidationRule = <T>(rule: unknown): rule is ValidationRule<unknown, T> => {
   return typeof rule === "function";
@@ -18,7 +17,7 @@ const isNestedValidationRules = <T>(
   return typeof rules === "object" && rules !== null && !Array.isArray(rules);
 };
 
-const validateCustom = <T extends Record<string, any>>(
+const validateCustom = <T extends Record<string, AllowedAny>>(
   values: T,
   schema: CustomValidationSchema<T>,
 ): Partial<Record<keyof T, unknown>> => {
@@ -29,11 +28,11 @@ const validateCustom = <T extends Record<string, any>>(
   const errors: Partial<Record<keyof T, unknown>> = {};
 
   const processValidationRule = (
-    rule: ValidationRule<any, T>,
+    rule: ValidationRule<AllowedAny, T>,
     fullKey: string,
     parentErrors: Record<string, unknown>,
   ) => {
-    const value = getNestedValue(values, fullKey as any);
+    const value = getNestedValue(values, fullKey);
     const error = rule(value, values);
 
     if (error !== undefined && error !== null) {

--- a/lib/composables/validation/index.ts
+++ b/lib/composables/validation/index.ts
@@ -19,7 +19,7 @@ const validate = <T extends object>(
     zodSchema?: ZodType<T>;
     validationSchema?: CustomValidationSchema<T>;
     customValidators?: AllowedAny;
-  }
+  },
 ): Partial<Record<keyof T, unknown>> => {
   let validationErrors: Partial<Record<keyof T, unknown>> = {};
 

--- a/lib/composables/validation/registry/index.ts
+++ b/lib/composables/validation/registry/index.ts
@@ -1,14 +1,20 @@
 import { AllowedAny } from "@/types";
 
 class ValidationRegistry {
-  private validators: Record<string, (values: AllowedAny, schema: AllowedAny) => Partial<Record<string, unknown>>> = {};
+  private validators: Record<
+    string,
+    (values: AllowedAny, schema: AllowedAny) => Partial<Record<string, unknown>>
+  > = {};
 
   /**
    * Registers a new validator in the registry.
    * @param name - The unique name of the validator (e.g., "zod", "yup", "joi").
    * @param fn - The validation function that processes the values using a schema.
    */
-  registerValidator(name: string, fn: (values: AllowedAny, schema: AllowedAny) => Partial<Record<string, unknown>>): void {
+  registerValidator(
+    name: string,
+    fn: (values: AllowedAny, schema: AllowedAny) => Partial<Record<string, unknown>>,
+  ): void {
     this.validators[name] = fn;
   }
 
@@ -17,7 +23,9 @@ class ValidationRegistry {
    * @param name - The name of the validator to retrieve.
    * @returns The validation function or null if not found.
    */
-  getValidator(name: string): ((values: AllowedAny, schema: AllowedAny) => Partial<Record<string, unknown>>) | null {
+  getValidator(
+    name: string,
+  ): ((values: AllowedAny, schema: AllowedAny) => Partial<Record<string, unknown>>) | null {
     return this.validators[name] || null;
   }
 

--- a/lib/composables/validation/registry/index.ts
+++ b/lib/composables/validation/registry/index.ts
@@ -1,0 +1,60 @@
+import { AllowedAny } from "@/types";
+
+class ValidationRegistry {
+  private validators: Record<string, (values: AllowedAny, schema: AllowedAny) => Partial<Record<string, unknown>>> = {};
+
+  /**
+   * Registers a new validator in the registry.
+   * @param name - The unique name of the validator (e.g., "zod", "yup", "joi").
+   * @param fn - The validation function that processes the values using a schema.
+   */
+  registerValidator(name: string, fn: (values: AllowedAny, schema: AllowedAny) => Partial<Record<string, unknown>>): void {
+    this.validators[name] = fn;
+  }
+
+  /**
+   * Retrieves a registered validator function.
+   * @param name - The name of the validator to retrieve.
+   * @returns The validation function or null if not found.
+   */
+  getValidator(name: string): ((values: AllowedAny, schema: AllowedAny) => Partial<Record<string, unknown>>) | null {
+    return this.validators[name] || null;
+  }
+
+  /**
+   * Checks if a validator is registered.
+   * @param name - The name of the validator.
+   * @returns `true` if registered, otherwise `false`.
+   */
+  hasValidator(name: string): boolean {
+    return name in this.validators;
+  }
+
+  /**
+   * Clears all registered validators (for testing purposes).
+   */
+  clearValidators(): void {
+    this.validators = {};
+  }
+
+  /**
+   * Retrieves all registered validator names.
+   * @returns An array of registered validator names.
+   */
+  getRegisteredValidators(): string[] {
+    return Object.keys(this.validators);
+  }
+
+  /**
+   * Checks if the validator is a default one.
+   *
+   * @param name - The name of the validator.
+   *
+   * @returns `true` if the validator is a default one, otherwise `false`.
+   */
+  isDefaultValidator(name?: string): boolean {
+    return name ? ["zod", "yup", "joi", "custom"].includes(name) : false;
+  }
+}
+
+export default ValidationRegistry;

--- a/lib/composables/validation/registry/util.ts
+++ b/lib/composables/validation/registry/util.ts
@@ -1,4 +1,4 @@
-import ValidationRegistry from "@/composables/validation/registry/index";
+import ValidationRegistry from "@/composables/validation/registry";
 import validateZod from "@/composables/validation/zod";
 import validateYup from "@/composables/validation/yup";
 import validateJoi from "@/composables/validation/joi";
@@ -13,4 +13,4 @@ export const getValidationRegistryWithDefaults = () => {
   vRegistry.registerValidator("custom", validateCustom);
 
   return vRegistry;
-}
+};

--- a/lib/composables/validation/registry/util.ts
+++ b/lib/composables/validation/registry/util.ts
@@ -1,0 +1,16 @@
+import ValidationRegistry from "@/composables/validation/registry/index";
+import validateZod from "@/composables/validation/zod";
+import validateYup from "@/composables/validation/yup";
+import validateJoi from "@/composables/validation/joi";
+import validateCustom from "@/composables/validation/custom";
+
+export const getValidationRegistryWithDefaults = () => {
+  const vRegistry = new ValidationRegistry();
+
+  vRegistry.registerValidator("zod", validateZod);
+  vRegistry.registerValidator("yup", validateYup);
+  vRegistry.registerValidator("joi", validateJoi);
+  vRegistry.registerValidator("custom", validateCustom);
+
+  return vRegistry;
+}

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -1,4 +1,6 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+type AllowedAny = any;
+
 import useFormik from "@/composables/useFormik";
 
 interface FormikHelpers<T> {
@@ -9,16 +11,16 @@ interface FormikHelpers<T> {
 }
 
 // Basic validation error types
-type ValidationResult<T = any> =
+type ValidationResult<T = AllowedAny> =
   | string
   | undefined
   | string[]
   | undefined[]
   | { [K in keyof T]?: ValidationResult<T[K]> }
-  | (T extends Array<any> ? Array<ValidationResult<T[number]>> : never);
+  | (T extends Array<AllowedAny> ? Array<ValidationResult<T[number]>> : never);
 
 // Enhanced validation rule with automatic type inference
-type ValidationRule<TValue = any, TForm = any> = (
+type ValidationRule<TValue = AllowedAny, TForm = AllowedAny> = (
   value: TValue,
   values: TForm,
 ) => ValidationResult<TValue>;
@@ -49,7 +51,7 @@ type DotNotationKeys<T> = {
 }[keyof T & string];
 
 type DotBasedValidationSchema<T> = Partial<{
-  [key in Exclude<DotNotationKeys<T>, keyof T>]: ValidationRule<any, T>;
+  [key in Exclude<DotNotationKeys<T>, keyof T>]: ValidationRule<AllowedAny, T>;
 }>;
 
 // Support both function and object validation schemas
@@ -70,7 +72,9 @@ type IResetOptions<T> = {
   keepTouched?: boolean;
 };
 
+
 export type {
+  AllowedAny,
   FormikHelpers,
   ValidationRule,
   ValidationResult,

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -72,7 +72,6 @@ type IResetOptions<T> = {
   keepTouched?: boolean;
 };
 
-
 export type {
   AllowedAny,
   FormikHelpers,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-formik",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "keywords": [
     "vue",
     "formik",


### PR DESCRIPTION
feat(validation): Implement dynamic validation registry integration  

- Added `ValidationRegistry` to handle multiple validation strategies dynamically (Zod, Yup, Joi, custom).  
- Updated `validate` function to retrieve validators from the registry and apply them conditionally.  
- Improved type inference for validation schemas and results.  
- Enhanced support for dot-based validation keys and nested validation rules.  

This update improves flexibility in handling different validation libraries while maintaining type safety.
